### PR TITLE
Throw exceptions on missing model properties

### DIFF
--- a/src/Demo.NEO.Models/DetectedNeoEvent.cs
+++ b/src/Demo.NEO.Models/DetectedNeoEvent.cs
@@ -5,19 +5,19 @@ namespace Demo.Neo.Models
 {
     public class DetectedNeoEvent
     {
-        [JsonProperty("id")]
+        [JsonProperty("id", Required = Required.Always)]
         public Guid Id { get; set; }
 
-        [JsonProperty("date")]
+        [JsonProperty("date", Required = Required.Always)]
         public DateTime Date { get; set; }
 
-        [JsonProperty("distance")]
+        [JsonProperty("distance", Required = Required.Always)]
         public float Distance { get; set; }
 
-        [JsonProperty("velocity")]
+        [JsonProperty("velocity", Required = Required.Always)]
         public float Velocity { get; set; }
 
-        [JsonProperty("diameter")]
+        [JsonProperty("diameter", Required = Required.Always)]
         public float Diameter { get; set; }
     }
 }

--- a/src/Demo.NEO.Models/ImpactProbabilityResult.cs
+++ b/src/Demo.NEO.Models/ImpactProbabilityResult.cs
@@ -5,10 +5,10 @@ namespace Demo.Neo.Models
 {
     public class ImpactProbabilityResult
     {
-        [JsonProperty("id")]
+        [JsonProperty("id", Required = Required.Always)]
         public Guid Id { get; set; }
 
-        [JsonProperty("impact_probability")]
+        [JsonProperty("impact_probability", Required = Required.Always)]
         public float ImpactProbability { get; set; }
     }
 }

--- a/src/Demo.NEO.Models/KineticEnergyResult.cs
+++ b/src/Demo.NEO.Models/KineticEnergyResult.cs
@@ -5,10 +5,10 @@ namespace Demo.Neo.Models
 {
     public class KineticEnergyResult
     {
-        [JsonProperty("id")]
+        [JsonProperty("id", Required = Required.Always)]
         public Guid Id { get; set; }
 
-        [JsonProperty("kinetic_energy_megaton_tnt")]
+        [JsonProperty("kinetic_energy_megaton_tnt", Required = Required.Always)]
         public float KineticEnergyInMegatonTnt { get; set; }
     }
 }

--- a/src/Demo.NEO.Models/ProcessedNeoEvent.cs
+++ b/src/Demo.NEO.Models/ProcessedNeoEvent.cs
@@ -12,7 +12,7 @@ namespace Demo.Neo.Models
             DetectedNeoEvent detectedNeoEvent,
             float kineticEnergyInMegatonTnt,
             float impactProbability,
-            int  torinoImpact)
+            int torinoImpact)
         {
             DateDetected = detectedNeoEvent.Date;
             Diameter = detectedNeoEvent.Diameter;
@@ -24,28 +24,28 @@ namespace Demo.Neo.Models
             TorinoImpact = torinoImpact;
         }
 
-        [JsonProperty("id")]
+        [JsonProperty("id", Required = Required.Always)]
         public Guid Id { get; set; }
 
-        [JsonProperty("date_detected")]
+        [JsonProperty("date_detected", Required = Required.Always)]
         public DateTime DateDetected { get; set; }
 
-        [JsonProperty("diameter")]
+        [JsonProperty("diameter", Required = Required.Always)]
         public float Diameter { get; set; }
 
-        [JsonProperty("distance")]
+        [JsonProperty("distance", Required = Required.Always)]
         public float Distance { get; set; }
 
-        [JsonProperty("velocity")]
+        [JsonProperty("velocity", Required = Required.Always)]
         public float Velocity { get; set; }
 
-        [JsonProperty("kinetic_energy_megaton_tnt")]
+        [JsonProperty("kinetic_energy_megaton_tnt", Required = Required.Always)]
         public float KineticEnergyInMegatonTnt { get; set; }
 
-        [JsonProperty("impact_probability")]
+        [JsonProperty("impact_probability", Required = Required.Always)]
         public float ImpactProbability { get; set; }
 
-        [JsonProperty("torino_impact")]
+        [JsonProperty("torino_impact", Required = Required.Always)]
         public int TorinoImpact { get; set; }
     }
 }

--- a/src/Demo.NEO.Models/TorinoImpactRequest.cs
+++ b/src/Demo.NEO.Models/TorinoImpactRequest.cs
@@ -5,13 +5,13 @@ namespace Demo.Neo.Models
 {
     public class TorinoImpactRequest
     {
-        [JsonProperty("id")]
+        [JsonProperty("id", Required = Required.Always)]
         public Guid Id { get; set; }
 
-        [JsonProperty("kinetic_energy_megaton_tnt")]
+        [JsonProperty("kinetic_energy_megaton_tnt", Required = Required.Always)]
         public float KineticEnergyInMegatonTnt { get; set; }
         
-        [JsonProperty("impact_probability")]
+        [JsonProperty("impact_probability", Required = Required.Always)]
         public float ImpactProbability { get; set; }
     }
 }

--- a/src/Demo.NEO.Models/TorinoImpactResult.cs
+++ b/src/Demo.NEO.Models/TorinoImpactResult.cs
@@ -5,10 +5,10 @@ namespace Demo.Neo.Models
 {
     public class TorinoImpactResult
     {
-        [JsonProperty("id")]
+        [JsonProperty("id", Required = Required.Always)]
         public Guid Id { get; set; }
 
-        [JsonProperty("torino_impact")]
+        [JsonProperty("torino_impact", Required = Required.Always)]
         public int TorinoImpact { get; set; }
     }
 }


### PR DESCRIPTION
Mark all JsonProperties as required so that Json.NET throws when deserializing into the models if any properties are missing.

This prevents errors where lab takers try to deserialize into the wrong type, for example into `ImpactProbabilityResult` instead of `TorinoImpactResult`.